### PR TITLE
Support for enums as record keys

### DIFF
--- a/test/parsers/record.test.ts
+++ b/test/parsers/record.test.ts
@@ -57,4 +57,19 @@ describe("records", () => {
     };
     expect(parsedSchema).toStrictEqual(expectedSchema);
   });
+
+  it("should be possible to describe a key with an enum", () => {
+    const schema = z.record(z.enum(["foo", "bar"]), z.number());
+    const parsedSchema = parseRecordDef(schema._def, new References());
+    const expectedSchema = {
+      type: "object",
+      additionalProperties: {
+        type: "number",
+      },
+      propertyNames: {
+        enum: ["foo", "bar"],
+      },
+    };
+    expect(parsedSchema).toStrictEqual(expectedSchema);
+  })
 });


### PR DESCRIPTION
This adds support for a `ZodEnum` to be used as record keys.

Example:

```typescript
zodToJsonSchema(
  z.record(
    z.enum(['foo', 'bar']),
    z.number()
  )
)
```
```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "additionalProperties": { "type": "number" },
  "propertyNames": { "enum": [ "foo", "bar" ] }
}
```