### PR TITLE
fix: reference paths when overriding schema name

### DIFF
--- a/src/zodToJsonSchema.ts
+++ b/src/zodToJsonSchema.ts
@@ -172,7 +172,9 @@ function zodToJsonSchema(
       $schema,
       $ref: `#/definitions/${name}`,
       definitions: {
-        [name]: parseDef(schema._def, new References()) || {},
+        [name]:
+          parseDef(schema._def, new References(["#", "definitions", name])) ||
+          {},
       },
     };
   } else {

--- a/test/references.test.ts
+++ b/test/references.test.ts
@@ -401,4 +401,68 @@ describe("Pathing", () => {
 
     expect(jsonSchema).toStrictEqual(exptectedResult);
   });
+
+  it("should preserve correct $ref when overriding name with string", () => {
+    const recurringSchema = z.string();
+    const objectSchema = z.object({
+      foo: recurringSchema,
+      bar: recurringSchema,
+    });
+
+    const jsonSchema = zodToJsonSchema(objectSchema, "hello");
+
+    const exptectedResult = {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $ref: "#/definitions/hello",
+      definitions: {
+        hello: {
+          type: "object",
+          properties: {
+            foo: {
+              type: "string",
+            },
+            bar: {
+              $ref: "#/definitions/hello/properties/foo",
+            },
+          },
+          required: ["foo", "bar"],
+          additionalProperties: false,
+        },
+      },
+    };
+
+    expect(jsonSchema).toStrictEqual(exptectedResult);
+  });
+
+  it("should preserve correct $ref when overriding name with object property", () => {
+    const recurringSchema = z.string();
+    const objectSchema = z.object({
+      foo: recurringSchema,
+      bar: recurringSchema,
+    });
+
+    const jsonSchema = zodToJsonSchema(objectSchema, { name: "hello" });
+
+    const exptectedResult = {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $ref: "#/definitions/hello",
+      definitions: {
+        hello: {
+          type: "object",
+          properties: {
+            foo: {
+              type: "string",
+            },
+            bar: {
+              $ref: "#/definitions/hello/properties/foo",
+            },
+          },
+          required: ["foo", "bar"],
+          additionalProperties: false,
+        },
+      },
+    };
+
+    expect(jsonSchema).toStrictEqual(exptectedResult);
+  });
 });


### PR DESCRIPTION
## Description
Fixes `$ref` paths when overriding schema name

## Current behavior
* `$ref` paths are correctly generated when overriding schema name using options object. For example:
```
zodToJsonSchema(objectSchema, { name: "hello" })
```
generates
```
#/definitions/hello/properties
```
* However, when overriding the schema name using `string` as second parameter to `zodToJsonSchema` method, the `$ref` are incorrectly generated. For example:
```
zodToJsonSchema(objectSchema, "hello")
```
generates:
```
#/properties
```

## Expected result
Both name overriding mechanism work the same way and `$ref` paths are always correctly generated