### PR TITLE
Fixes to allow const assertions in nativeEnum

### DIFF
--- a/src/parsers/nativeEnum.ts
+++ b/src/parsers/nativeEnum.ts
@@ -8,19 +8,17 @@ export type JsonSchema7NativeEnumType = {
 export function parseNativeEnumDef(
   def: ZodNativeEnumDef
 ): JsonSchema7NativeEnumType {
-  const numberValues = Object.values(def.values)
-    .filter((value) => typeof value === "number")
-    .map(toString);
-  const actualValues = Object.values(def.values).filter(
-    (_, i) => i >= numberValues.length
-  );
+  const object = def.values;
+  const actualKeys = Object.keys(def.values).filter((key: string) => {
+    return typeof object[object[key]] !== 'number'
+  });
+
+  const actualValues = actualKeys.map((key: string) => object[key]);
+
+  const parsedTypes = Array.from(new Set(actualValues.map((values: string | number) => (typeof values))));
+
   return {
-    type:
-      numberValues.length === 0
-        ? "string"
-        : numberValues.length === actualValues.length
-        ? "number"
-        : ["string", "number"],
+    type: parsedTypes.length === 1 ? parsedTypes[0] === 'string' ? "string" : "number" : ["string", "number"],
     enum: actualValues,
   };
 }

--- a/test/parsers/nativeEnum.test.ts
+++ b/test/parsers/nativeEnum.test.ts
@@ -47,4 +47,50 @@ describe('Native enums', () => {
     };
     expect(parsedSchema).toStrictEqual(jsonSchema);
   });
+
+  it('should be possible to convert a native const assertion object', () => {
+    const MyConstAssertionObject = {
+      val1: 0,
+      val2: 1,
+      val3: 2
+    } as const
+
+    const parsedSchema = parseNativeEnumDef(z.nativeEnum(MyConstAssertionObject)._def);
+    const jsonSchema: JSONSchema7Type = {
+      type: 'number',
+      enum: [0, 1, 2],
+    };
+    expect(parsedSchema).toStrictEqual(jsonSchema);
+  })
+
+  it('should be possible to convert a native const assertion string object', () => {
+    const MyConstAssertionObject = {
+      val1: 'a',
+      val2: 'b',
+      val3: 'c'
+    } as const
+
+    const parsedSchema = parseNativeEnumDef(z.nativeEnum(MyConstAssertionObject)._def);
+    const jsonSchema: JSONSchema7Type = {
+      type: 'string',
+      enum: ['a', 'b', 'c'],
+    };
+    expect(parsedSchema).toStrictEqual(jsonSchema);
+  })
+
+
+  it('should be possible to convert a mixed value native const assertion string object', () => {
+    const MyConstAssertionObject = {
+      val1: 'a',
+      val2: 1,
+      val3: 'c'
+    } as const
+
+    const parsedSchema = parseNativeEnumDef(z.nativeEnum(MyConstAssertionObject)._def);
+    const jsonSchema: JSONSchema7Type = {
+      type: ['string', 'number'],
+      enum: ['a', 1, 'c'],
+    };
+    expect(parsedSchema).toStrictEqual(jsonSchema);
+  })
 });


### PR DESCRIPTION
## Bug Description
Zod can use const enum in `z.nativeEnum()` , but zod-to-json-schema did not parse them correctly.
- https://github.com/colinhacks/zod#native-enums

```typescript

// input
const values = {
  val1: 1,
  val2: 2,
} as const

const actualValues = Object.values(values).filter(
    (_, i) => i >= numberValues.length
);

console.log({
    type:
      numberValues.length === 0
        ? "string"
        : numberValues.length === actualValues.length
        ? "number"
        : ["string", "number"],
    enum: actualValues,
  })
// output
// {
//   "type": [
//     "string",
//     "number"
//   ],
//   "enum": []
// } 

```

## Fix
Fixed to correctly parse both in the case of enum and const enums object.