### PR TITLE
Fix strictUnions option not working in objects

### DIFF
--- a/src/References.ts
+++ b/src/References.ts
@@ -35,7 +35,8 @@ export class References {
       this.$refStrategy,
       this.effectStrategy,
       this.target,
-      this.propertyPath
+      this.propertyPath,
+      this.strictUnions
     );
   }
 
@@ -46,7 +47,8 @@ export class References {
       this.$refStrategy,
       this.effectStrategy,
       this.target,
-      [...this.currentPath, ...path]
+      [...this.currentPath, ...path],
+      this.strictUnions
     );
   }
 }

--- a/test/zodToJsonSchema.test.ts
+++ b/test/zodToJsonSchema.test.ts
@@ -52,4 +52,22 @@ describe("Root schema result after parsing", () => {
       anyOf: [{ type: "string" }, { type: "number" }],
     });
   });
+
+  it("should scrub 'any'-schemas from unions when strictUnions=true in objects", () => {
+    expect(
+      zodToJsonSchema(
+        z.object({
+          field: z.union([z.any(), z.instanceof(String), z.string(), z.number()]),
+        }),
+        { strictUnions: true }
+      )
+    ).toStrictEqual({
+      $schema: "http://json-schema.org/draft-07/schema#",
+      additionalProperties: false,
+      properties: {
+        field: { anyOf: [{ type: "string" }, { type: "number" }] },
+      },
+      type: "object",
+    });
+  });
 });


### PR DESCRIPTION
Hey, thanks for writing this library, it's super helpful.
My use case involves an object that had an id that is a mongo object id:

```typescript
const objectId = z.union([
  z.instanceof(mongoose.Types.ObjectId),
  z
    .string()
    .regex(/^[a-f0-9]{24}$/, { message: 'This string does not look like an ObjectId()' })
    .transform((s) => new mongoose.Types.ObjectId(s)),
]);

export const schema = z.object({
  someId: objectId,
});
```

The problem is that `someId` gets transformed to:
```json
{
  "anyOf": [
    {},
    {
      "type": "string",
      "pattern": "^[a-f0-9]{24}$"
    }
  ]
}
```

I added a test and a fix for this bug.