### PR TITLE
Adds custom error messages. closes StefanTerdell/zod-to-json-schema#26

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "John Wright (https://github.com/johngeorgewright)",
     "Krzysztof Ciombor (https://github.com/krzysztofciombor)",
     "Yuta Mombetsu (https://github.com/mokocm)",
-    "Tom Arad (https://github.com/tomarad)"
+    "Tom Arad (https://github.com/tomarad)",
+    "Isaac Way (https://github.com/iway1)"
   ],
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,7 @@ Instead of the schema name (or nothing), you can pass an options object as the s
 | **target**?: "jsonSchema7" \| "openApi3"          | Which spec to target. Defaults to "jsonSchema7"                                                                                                                                                                                                                                                                                                                                                                                                              |
 | **strictUnions**?: boolean                        | Scrubs unions of any-like json schemas, like `{}` or `true`. Multiple zod types may result in these out of necessity, such as z.instanceof()                                                                                                                                                                                                                                                                                                                 |
 | **definitions**?: Record<string, ZodSchema>       | See separate section below                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **errorMessages**?: boolean                       | Include custom error messages created via chained function checks for supported zod types. See section below                                                                                                                                                                                                                                                                                                                                                 |
 
 ### Definitions
 
@@ -112,6 +113,50 @@ const myJsonSchema = zodToJsonSchema(myObjectSchema, {
   }
 }
 ```
+
+### Error Messages
+
+This feature allows optionally including error messages created via chained function calls for supported zod types:
+
+```ts
+// string schema with additional chained function call checks
+const EmailSchema = z.string().email("Invalid email").min(5, "Too short");
+
+const jsonSchema = zodToJsonSchema(EmailSchema, {errorMessages: true})
+```
+
+#### Result
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "string",
+  "format": "email",
+  "minLength": 5,
+  "errorMessage": {
+    "format": "Invalid email",
+    "minLength": "Too short",
+  }
+}
+```
+
+This allows for field specific, validation step specific error messages which can be useful for building forms and such. This format is accepted by `react-hook-form`'s ajv resolver (and therefor `ajv-errors` which it uses under the hood). Note that if using AJV with this format will require [enabling `ajv-errors`](https://ajv.js.org/packages/ajv-errors.html#usage) as vanilla AJV does not accept this format by default.
+
+#### Custom Error Message Support
+
+- ZodString
+  - regex
+  - min, max
+  - email, cuid, uuid, url
+  - endsWith, startsWith
+- ZodNumber
+  - min, max, lt, lte, gt, gte, 
+  - int
+  - multipleOf
+- ZodSet
+  - min, max
+- ZodArray
+  - min, max
 
 ## Known issues
 

--- a/src/References.ts
+++ b/src/References.ts
@@ -7,8 +7,9 @@ export class References {
   $refStrategy: $refStrategy;
   effectStrategy: EffectStrategy;
   target: Target;
-  propertyPath: string[]
-  strictUnions: boolean
+  propertyPath: string[];
+  strictUnions: boolean;
+  errorMessages: boolean;
 
   constructor(
     path: string[] = ["#"],
@@ -17,7 +18,8 @@ export class References {
     effectStrategy: EffectStrategy = "input",
     target: Target = "jsonSchema7",
     propertyPath: string[] = [],
-    strictUnions = false
+    strictUnions = false,
+    errorMessages = false
   ) {
     this.currentPath = path;
     this.items = items;
@@ -25,7 +27,8 @@ export class References {
     this.effectStrategy = effectStrategy;
     this.target = target;
     this.propertyPath = propertyPath;
-    this.strictUnions = strictUnions
+    this.strictUnions = strictUnions;
+    this.errorMessages = errorMessages;
   }
 
   addToPath(...path: string[]) {
@@ -36,7 +39,8 @@ export class References {
       this.effectStrategy,
       this.target,
       this.propertyPath,
-      this.strictUnions
+      this.strictUnions,
+      this.errorMessages
     );
   }
 
@@ -48,7 +52,8 @@ export class References {
       this.effectStrategy,
       this.target,
       [...this.currentPath, ...path],
-      this.strictUnions
+      this.strictUnions,
+      this.errorMessages
     );
   }
 }

--- a/src/errorMessages.ts
+++ b/src/errorMessages.ts
@@ -1,0 +1,42 @@
+import { JsonSchema7TypeUnion } from "./parseDef";
+import { References } from "./References";
+
+export type ErrorMessages<
+  T extends JsonSchema7TypeUnion,
+  OmitProperties extends string = ""
+> = Partial<
+  Omit<{ [key in keyof T]: string }, OmitProperties | "type" | "errorMessages">
+>;
+
+export function addErrorMessage<
+  T extends { errorMessage?: ErrorMessages<any> }
+>(
+  res: T,
+  key: keyof T,
+  errorMessage: string | undefined,
+  references: References
+) {
+  if (!references?.errorMessages) return;
+  if (errorMessage) {
+    res.errorMessage = {
+      ...res.errorMessage,
+      [key]: errorMessage,
+    };
+  }
+}
+
+export function setResponseValueAndErrors<
+  Json7Type extends JsonSchema7TypeUnion & {
+    errorMessage?: ErrorMessages<Json7Type>;
+  },
+  Key extends keyof Omit<Json7Type, "errorMessage">
+>(
+  res: Json7Type,
+  key: Key,
+  value: Json7Type[Key],
+  errorMessage: string | undefined,
+  references: References
+) {
+  res[key] = value;
+  addErrorMessage(res, key, errorMessage, references);
+}

--- a/src/parseDef.ts
+++ b/src/parseDef.ts
@@ -39,7 +39,7 @@ import { Item, References } from "./References";
 
 type JsonSchema7RefType = { $ref: string };
 
-export type JsonSchema7Type = (
+export type JsonSchema7TypeUnion =
   | JsonSchema7StringType
   | JsonSchema7ArrayType
   | JsonSchema7NumberType
@@ -63,8 +63,12 @@ export type JsonSchema7Type = (
   | JsonSchema7NullableType
   | JsonSchema7AllOfType
   | JsonSchema7UnknownType
-  | JsonSchema7SetType
-) & { default?: any; description?: string }
+  | JsonSchema7SetType;
+
+export type JsonSchema7Type = JsonSchema7TypeUnion & {
+  default?: any;
+  description?: string;
+};
 
 export function parseDef(
   def: ZodTypeDef,
@@ -160,7 +164,7 @@ const selectParser = (
 ): JsonSchema7Type | undefined => {
   switch (typeName) {
     case ZodFirstPartyTypeKind.ZodString:
-      return parseStringDef(def);
+      return parseStringDef(def, refs);
     case ZodFirstPartyTypeKind.ZodNumber:
       return parseNumberDef(def, refs);
     case ZodFirstPartyTypeKind.ZodObject:
@@ -252,17 +256,17 @@ const getPreloadedDefinitionSchemas = (
             refs
           );
 
-          if (jsonSchema) {
-            refs.items.push({
-              def: schema._def,
-              path: [...options.basePath, options.definitionsPath, key],
-              jsonSchema,
-            });
+        if (jsonSchema) {
+          refs.items.push({
+            def: schema._def,
+            path: [...options.basePath, options.definitionsPath, key],
+            jsonSchema,
+          });
 
-            acc[key] = jsonSchema;
-          }
+          acc[key] = jsonSchema;
+        }
 
-          return acc;
+        return acc;
         },
         {}
       )

--- a/src/parsers/array.ts
+++ b/src/parsers/array.ts
@@ -1,4 +1,5 @@
 import { ZodArrayDef, ZodFirstPartyTypeKind } from "zod";
+import { ErrorMessages, setResponseValueAndErrors } from "../errorMessages";
 import { JsonSchema7Type, parseDef } from "../parseDef";
 import { References } from "../References";
 
@@ -7,6 +8,7 @@ export type JsonSchema7ArrayType = {
   items?: JsonSchema7Type;
   minItems?: number;
   maxItems?: number;
+  errorMessages?: ErrorMessages<JsonSchema7ArrayType, "items">;
 };
 
 export function parseArrayDef(def: ZodArrayDef, refs: References) {
@@ -17,10 +19,22 @@ export function parseArrayDef(def: ZodArrayDef, refs: References) {
     res.items = parseDef(def.type._def, refs.addToPath("items"));
   }
   if (def.minLength) {
-    res.minItems = def.minLength.value;
+    setResponseValueAndErrors(
+      res,
+      "minItems",
+      def.minLength.value,
+      def.minLength.message,
+      refs
+    );
   }
   if (def.maxLength) {
-    res.maxItems = def.maxLength.value;
+    setResponseValueAndErrors(
+      res,
+      "maxItems",
+      def.maxLength.value,
+      def.maxLength.message,
+      refs
+    );
   }
 
   return res;

--- a/src/parsers/number.ts
+++ b/src/parsers/number.ts
@@ -1,4 +1,9 @@
 import { ZodNumberDef } from "zod";
+import {
+  addErrorMessage,
+  ErrorMessages,
+  setResponseValueAndErrors,
+} from "../errorMessages";
 import { References } from "../References";
 
 export type JsonSchema7NumberType = {
@@ -8,6 +13,7 @@ export type JsonSchema7NumberType = {
   maximum?: number;
   exclusiveMaximum?: number;
   multipleOf?: number;
+  errorMessage?: ErrorMessages<JsonSchema7NumberType>;
 };
 
 export function parseNumberDef(
@@ -18,46 +24,88 @@ export function parseNumberDef(
     type: "number",
   };
 
-  if (def.checks) {
-    for (const check of def.checks) {
-      switch (check.kind) {
-        case "int":
-          res.type = "integer";
-          break;
-        case "min":
-          if (refs.target === "jsonSchema7") {
-            if (check.inclusive) {
-              res.minimum = check.value;
-            } else {
-              res.exclusiveMinimum = check.value;
-            }
+  if (!def.checks) return res;
+
+  for (const check of def.checks) {
+    switch (check.kind) {
+      case "int":
+        res.type = "integer";
+        addErrorMessage(res, "type", check.message, refs);
+        break;
+      case "min":
+        if (refs.target === "jsonSchema7") {
+          if (check.inclusive) {
+            setResponseValueAndErrors(
+              res,
+              "minimum",
+              check.value,
+              check.message,
+              refs
+            );
           } else {
-            if (!check.inclusive) {
-              res.exclusiveMinimum = true as any;
-            }
-            res.minimum = check.value;
+            setResponseValueAndErrors(
+              res,
+              "exclusiveMinimum",
+              check.value,
+              check.message,
+              refs
+            );
           }
-          break;
-        case "max":
-          if (refs.target === "jsonSchema7") {
-            if (check.inclusive) {
-              res.maximum = check.value;
-            } else {
-              res.exclusiveMaximum = check.value;
-            }
+        } else {
+          if (!check.inclusive) {
+            res.exclusiveMinimum = true as any;
+          }
+          setResponseValueAndErrors(
+            res,
+            "minimum",
+            check.value,
+            check.message,
+            refs
+          );
+        }
+        break;
+      case "max":
+        if (refs.target === "jsonSchema7") {
+          if (check.inclusive) {
+            setResponseValueAndErrors(
+              res,
+              "maximum",
+              check.value,
+              check.message,
+              refs
+            );
           } else {
-            if (!check.inclusive) {
-              res.exclusiveMaximum = true as any;
-            }
-            res.maximum = check.value;
+            setResponseValueAndErrors(
+              res,
+              "exclusiveMaximum",
+              check.value,
+              check.message,
+              refs
+            );
           }
-          break;
-        case "multipleOf":
-          res.multipleOf = check.value;
-          break;
-      }
+        } else {
+          if (!check.inclusive) {
+            res.exclusiveMaximum = true as any;
+          }
+          setResponseValueAndErrors(
+            res,
+            "maximum",
+            check.value,
+            check.message,
+            refs
+          );
+        }
+        break;
+      case "multipleOf":
+        setResponseValueAndErrors(
+          res,
+          "multipleOf",
+          check.value,
+          check.message,
+          refs
+        );
+        break;
     }
   }
-
   return res;
 }

--- a/src/parsers/record.ts
+++ b/src/parsers/record.ts
@@ -28,7 +28,7 @@ export function parseRecordDef(
     def.keyType._def.checks?.length
   ) {
     const keyType: JsonSchema7RecordPropertyNamesType = Object.entries(
-      parseStringDef(def.keyType._def)
+      parseStringDef(def.keyType._def, refs)
     ).reduce(
       (acc, [key, value]) => (key === "type" ? acc : { ...acc, [key]: value }),
       {}

--- a/src/parsers/set.ts
+++ b/src/parsers/set.ts
@@ -1,4 +1,5 @@
 import { ZodSetDef } from "zod";
+import { ErrorMessages, setResponseValueAndErrors } from "../errorMessages";
 import { JsonSchema7Type, parseDef } from "../parseDef";
 import { References } from "../References";
 
@@ -7,6 +8,7 @@ export type JsonSchema7SetType = {
   items?: JsonSchema7Type;
   minItems?: number;
   maxItems?: number;
+  errorMessage?: ErrorMessages<JsonSchema7SetType>;
 };
 
 export function parseSetDef(
@@ -21,11 +23,23 @@ export function parseSetDef(
   }
 
   if (def.minSize) {
-    schema.minItems = def.minSize.value
+    setResponseValueAndErrors(
+      schema,
+      "minItems",
+      def.minSize.value,
+      def.minSize.message,
+      refs
+    );
   }
 
   if (def.maxSize) {
-    schema.maxItems = def.maxSize.value
+    setResponseValueAndErrors(
+      schema,
+      "maxItems",
+      def.maxSize.value,
+      def.maxSize.message,
+      refs
+    );
   }
 
   return schema

--- a/src/parsers/string.ts
+++ b/src/parsers/string.ts
@@ -1,4 +1,6 @@
 import { ZodStringDef } from "zod";
+import { ErrorMessages, setResponseValueAndErrors } from "../errorMessages";
+import { References } from "../References";
 
 export type JsonSchema7StringType = {
   type: "string";
@@ -6,10 +8,17 @@ export type JsonSchema7StringType = {
   maxLength?: number;
   format?: "email" | "uri" | "uuid";
   pattern?: string;
-  allOf?: { pattern: string }[];
+  allOf?: {
+    pattern: string;
+    errorMessage?: ErrorMessages<{ pattern: string }>;
+  }[];
+  errorMessage?: ErrorMessages<JsonSchema7StringType>;
 };
 
-export function parseStringDef(def: ZodStringDef): JsonSchema7StringType {
+export function parseStringDef(
+  def: ZodStringDef,
+  references: References
+): JsonSchema7StringType {
   const res: JsonSchema7StringType = {
     type: "string",
   };
@@ -18,37 +27,76 @@ export function parseStringDef(def: ZodStringDef): JsonSchema7StringType {
     for (const check of def.checks) {
       switch (check.kind) {
         case "min":
-          res.minLength =
+          setResponseValueAndErrors(
+            res,
+            "minLength",
             typeof res.minLength === "number"
               ? Math.max(res.minLength, check.value)
-              : check.value;
+              : check.value,
+            check.message,
+            references
+          );
           break;
         case "max":
-          res.maxLength =
+          setResponseValueAndErrors(
+            res,
+            "maxLength",
             typeof res.maxLength === "number"
               ? Math.min(res.maxLength, check.value)
-              : check.value;
+              : check.value,
+            check.message,
+            references
+          );
+
           break;
         case "email":
-          res.format = "email";
+          setResponseValueAndErrors(
+            res,
+            "format",
+            "email",
+            check.message,
+            references
+          );
           break;
         case "url":
-          res.format = "uri";
+          setResponseValueAndErrors(
+            res,
+            "format",
+            "uri",
+            check.message,
+            references
+          );
           break;
         case "uuid":
-          res.format = "uuid";
+          setResponseValueAndErrors(
+            res,
+            "format",
+            "uuid",
+            check.message,
+            references
+          );
           break;
         case "regex":
-          addPattern(res, check.regex.source);
+          addPattern(res, check.regex.source, check.message, references);
           break;
         case "cuid":
-          addPattern(res, "^c[^\\s-]{8,}$");
+          addPattern(res, "^c[^\\s-]{8,}$", check.message, references);
           break;
         case "startsWith":
-          addPattern(res, "^" + escapeNonAlphaNumeric(check.value));
+          addPattern(
+            res,
+            "^" + escapeNonAlphaNumeric(check.value),
+            check.message,
+            references
+          );
           break;
         case "endsWith":
-          addPattern(res, escapeNonAlphaNumeric(check.value) + "$");
+          addPattern(
+            res,
+            escapeNonAlphaNumeric(check.value) + "$",
+            check.message,
+            references
+          );
           break;
         case "trim":
           // I have no idea why this is a check in Zod. It's a runtime string manipulation method.
@@ -67,19 +115,40 @@ const escapeNonAlphaNumeric = (value: string) =>
     .map((c) => (/[a-zA-Z0-9]/.test(c) ? c : `\\${c}`))
     .join("");
 
-const addPattern = (schema: JsonSchema7StringType, value: string) => {
+const addPattern = (
+  schema: JsonSchema7StringType,
+  value: string,
+  message: string | undefined,
+  references: References
+) => {
   if (schema.pattern || schema.allOf?.some((x) => x.pattern)) {
     if (!schema.allOf) {
       schema.allOf = [];
     }
 
     if (schema.pattern) {
-      schema.allOf!.push({ pattern: schema.pattern });
+      schema.allOf!.push({
+        pattern: schema.pattern,
+        ...(schema.errorMessage &&
+          references.errorMessages && {
+            errorMessage: { pattern: schema.errorMessage.pattern },
+          }),
+      });
       delete schema.pattern;
+      if (schema.errorMessage) {
+        delete schema.errorMessage.pattern;
+        if (Object.keys(schema.errorMessage).length === 0) {
+          delete schema.errorMessage;
+        }
+      }
     }
 
-    schema.allOf!.push({ pattern: value });
+    schema.allOf!.push({
+      pattern: value,
+      ...(message &&
+        references.errorMessages && { errorMessage: { pattern: message } }),
+    });
   } else {
-    schema.pattern = value;
+    setResponseValueAndErrors(schema, "pattern", value, message, references);
   }
 };

--- a/src/zodToJsonSchema.ts
+++ b/src/zodToJsonSchema.ts
@@ -51,6 +51,7 @@ function zodToJsonSchema<
     target?: Target;
     strictUnions?: boolean;
     definitions?: Definitions;
+    errorMessages?: boolean;
   }
 ): Target extends "openApi3"
   ? Name extends string
@@ -107,6 +108,7 @@ function zodToJsonSchema(
         target?: Target;
         strictUnions?: boolean;
         definitions?: Record<string, ZodSchema<any>>;
+        errorMessages?: boolean;
       }
     | string
 ) {
@@ -130,7 +132,8 @@ function zodToJsonSchema(
         options.effectStrategy,
         options.target,
         undefined,
-        options.strictUnions
+        options.strictUnions,
+        options.errorMessages
       ),
       options.definitions && {
         basePath,

--- a/test/parsers/errorReferences.ts
+++ b/test/parsers/errorReferences.ts
@@ -1,0 +1,7 @@
+import { References } from "../../src/References";
+
+export function errorReferences(): References {
+  const r = new References();
+  r.errorMessages = true;
+  return r;
+}

--- a/test/parsers/number.test.ts
+++ b/test/parsers/number.test.ts
@@ -2,6 +2,7 @@ import { JSONSchema7Type } from "json-schema";
 import { z } from "zod";
 import { parseNumberDef } from "../../src/parsers/number";
 import { References } from "../../src/References";
+import { errorReferences } from "./errorReferences";
 describe("Number validations", () => {
   it("should be possible to describe minimum number", () => {
     const parsedSchema = parseNumberDef(
@@ -71,5 +72,101 @@ describe("Number validations", () => {
       exclusiveMinimum: 0,
     };
     expect(parsedSchema).toStrictEqual(jsonSchema);
+  });
+  it("should include custom error messages for inclusive checks if they're passed", () => {
+    const minErrorMessage = "Number must be at least 5";
+    const maxErrorMessage = "Number must be at most 10";
+    const zodNumberSchema = z
+      .number()
+      .gte(5, minErrorMessage)
+      .lte(10, maxErrorMessage);
+    const jsonSchema: JSONSchema7Type = {
+      type: "number",
+      minimum: 5,
+      maximum: 10,
+      errorMessage: {
+        minimum: minErrorMessage,
+        maximum: maxErrorMessage,
+      },
+    };
+    const jsonParsedSchema = parseNumberDef(
+      zodNumberSchema._def,
+      errorReferences()
+    );
+    expect(jsonParsedSchema).toStrictEqual(jsonSchema);
+  });
+  it("should include custom error messages for exclusive checks if they're passed", () => {
+    const minErrorMessage = "Number must be greater than 5";
+    const maxErrorMessage = "Number must less than 10";
+    const zodNumberSchema = z
+      .number()
+      .gt(5, minErrorMessage)
+      .lt(10, maxErrorMessage);
+    const jsonSchema: JSONSchema7Type = {
+      type: "number",
+      exclusiveMinimum: 5,
+      exclusiveMaximum: 10,
+      errorMessage: {
+        exclusiveMinimum: minErrorMessage,
+        exclusiveMaximum: maxErrorMessage,
+      },
+    };
+    const jsonParsedSchema = parseNumberDef(
+      zodNumberSchema._def,
+      errorReferences()
+    );
+    expect(jsonParsedSchema).toStrictEqual(jsonSchema);
+  });
+  it("should include custom error messages for multipleOf and int if they're passed", () => {
+    const intErrorMessage = "Must be an integer";
+    const multipleOfErrorMessage = "Must be a multiple of 5";
+    const jsonSchema: JSONSchema7Type = {
+      type: "integer",
+      multipleOf: 5,
+      errorMessage: {
+        type: intErrorMessage,
+        multipleOf: multipleOfErrorMessage,
+      },
+    };
+    const zodNumberSchema = z
+      .number()
+      .multipleOf(5, multipleOfErrorMessage)
+      .int(intErrorMessage);
+    const jsonParsedSchema = parseNumberDef(
+      zodNumberSchema._def,
+      errorReferences()
+    );
+    expect(jsonParsedSchema).toStrictEqual(jsonSchema);
+  });
+  it("should not include errorMessage property if they're not passed", () => {
+    const zodNumberSchemas = [
+      z.number().lt(5),
+      z.number().gt(5),
+      z.number().gte(5),
+      z.number().lte(5),
+      z.number().multipleOf(5),
+      z.number().int(),
+      z.number().int().multipleOf(5).lt(5).gt(3).lte(4).gte(3),
+    ];
+    const jsonParsedSchemas = zodNumberSchemas.map((schema) =>
+      parseNumberDef(schema._def, errorReferences())
+    );
+    for (const jsonParsedSchema of jsonParsedSchemas) {
+      expect(jsonParsedSchema.errorMessage).toBe(undefined);
+    }
+  });
+  it("should not include error messages if error message isn't explicitly set to true in References constructor", () => {
+    const zodNumberSchemas = [
+      z.number().lt(5),
+      z.number().gt(5),
+      z.number().gte(5),
+      z.number().lte(5),
+      z.number().multipleOf(5),
+      z.number().int(),
+    ];
+    for (const schema of zodNumberSchemas) {
+      const jsonParsedSchema = parseNumberDef(schema._def, new References());
+      expect(jsonParsedSchema.errorMessage).toBeUndefined();
+    }
   });
 });

--- a/test/parsers/set.test.ts
+++ b/test/parsers/set.test.ts
@@ -1,0 +1,42 @@
+import { JSONSchema7Type } from "json-schema";
+import { z } from "zod";
+import { parseSetDef } from "../../src/parsers/set";
+import { References } from "../../src/References";
+import { errorReferences } from "./errorReferences";
+
+describe("set", () => {
+  it("should include min and max size error messages if they're passed.", () => {
+    const minSizeError = "Set must have at least 5 elements";
+    const maxSizeError = "Set can't have more than 10 elements";
+    const errs = {
+      minItems: minSizeError,
+      maxItems: maxSizeError,
+    };
+    const jsonSchema: JSONSchema7Type = {
+      type: "array",
+      minItems: 5,
+      maxItems: 10,
+      errorMessage: errs,
+      items: {},
+    };
+    const zodSchema = z.set(z.any()).min(5, minSizeError).max(10, maxSizeError);
+    const jsonParsedSchema = parseSetDef(zodSchema._def, errorReferences());
+    expect(jsonParsedSchema).toStrictEqual(jsonSchema);
+  });
+  it("should not include error messages if none are passed", () => {
+    const jsonSchema: JSONSchema7Type = {
+      type: "array",
+      minItems: 5,
+      maxItems: 10,
+      items: {},
+    };
+    const zodSchema = z.set(z.any()).min(5).max(10);
+    const jsonParsedSchema = parseSetDef(zodSchema._def, errorReferences());
+    expect(jsonParsedSchema).toStrictEqual(jsonSchema);
+  });
+  it("should not include error messages if it's not explicitly set to true in the References constructor", () => {
+    const zodSchema = z.set(z.any()).min(1, "bad").max(5, "vbad");
+    const jsonParsedSchema = parseSetDef(zodSchema._def, new References());
+    expect(jsonParsedSchema.errorMessage).toBeUndefined();
+  });
+});

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -4,8 +4,8 @@ import zodToJsonSchema from '..';
 describe('The readme example', () => {
   it('should be valid', () => {
     const mySchema = z.object({
-      myString: z.string().min(5),
-      myUnion: z.union([z.number(), z.boolean()]),
+        myString: z.string().min(5),
+        myUnion: z.union([z.number(), z.boolean()]),
     }).describe("My neat object schema");
 
     const jsonSchema = zodToJsonSchema(mySchema, 'mySchema');
@@ -31,5 +31,20 @@ describe('The readme example', () => {
         },
       },
     });
+  });
+  it('should have a valid error message example', () => {
+    const EmailSchema = z.string().email("Invalid email").min(5, "Too short");
+    const expected = {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "format": "email",
+      "minLength": 5,
+      "errorMessage": {
+        "format": "Invalid email",
+        "minLength": "Too short",
+      }
+    };
+    const parsedJsonSchema = zodToJsonSchema(EmailSchema, {errorMessages: true});
+    expect(parsedJsonSchema).toStrictEqual(expected);
   });
 });


### PR DESCRIPTION
Discussion in #26.

Adds optional error messages to chained function call checks to string, set, array, and number. 
IE
```ts
zodToJsonSchema(someSchema, {errorMessages: true})

z.string().min("string too short") // {type: 'string', minLength: 5, errorMessage: {minLength: 'string too short'}}
```

- [X] Implementation
- [X] Tests
- [X] Readme 