### PR TITLE
🏷️ Target based return type

### DIFF
--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,16 +1,17 @@
 import { ZodSchema } from "zod";
 
-export type Options = {
-  name: string | undefined;
-  $refStrategy: "root" | "relative" | "none";
-  basePath: string[];
-  effectStrategy: "input" | "any";
-  target: "jsonSchema7" | "openApi3";
-  strictUnions: boolean;
-  definitionPath: string;
-  definitions: Record<string, ZodSchema>;
-  errorMessages: boolean
-};
+export type Options<Target extends "jsonSchema7" | "openApi3" = "jsonSchema7"> =
+  {
+    name: string | undefined;
+    $refStrategy: "root" | "relative" | "none";
+    basePath: string[];
+    effectStrategy: "input" | "any";
+    target: Target;
+    strictUnions: boolean;
+    definitionPath: string;
+    definitions: Record<string, ZodSchema>;
+    errorMessages: boolean;
+  };
 
 export const defaultOptions: Options = {
   name: undefined,
@@ -21,13 +22,13 @@ export const defaultOptions: Options = {
   target: "jsonSchema7",
   strictUnions: false,
   definitions: {},
-  errorMessages: false
+  errorMessages: false,
 };
 
-export const getDefaultOptions = (
-  options: Partial<Options> | string | undefined
-): Options =>
-  typeof options === "string"
+export const getDefaultOptions = <Target extends "jsonSchema7" | "openApi3">(
+  options: Partial<Options<Target>> | string | undefined
+) =>
+  (typeof options === "string"
     ? {
         ...defaultOptions,
         name: options,
@@ -35,4 +36,4 @@ export const getDefaultOptions = (
     : {
         ...defaultOptions,
         ...options,
-      };
+      }) as Options<Target>;

--- a/src/Refs.ts
+++ b/src/Refs.ts
@@ -6,7 +6,7 @@ export type Refs = {
   seen: Seen[];
   currentPath: string[];
   propertyPath: string[] | undefined;
-} & Options;
+} & Options<"jsonSchema7" | "openApi3">;
 
 export type Seen = {
   def: ZodTypeDef;
@@ -14,7 +14,9 @@ export type Seen = {
   jsonSchema: JsonSchema7Type | undefined;
 };
 
-export const getRefs = (options?: string | Partial<Options>): Refs => {
+export const getRefs = (
+  options?: string | Partial<Options<"jsonSchema7" | "openApi3">>
+): Refs => {
   const _options = getDefaultOptions(options);
   const currentPath =
     _options.name !== undefined

--- a/src/zodToJsonSchema.ts
+++ b/src/zodToJsonSchema.ts
@@ -4,12 +4,16 @@ import { Options } from "./Options";
 import { JsonSchema7Type, parseDef } from "./parseDef";
 import { getRefs } from "./Refs";
 
-const zodToJsonSchema = (
+const zodToJsonSchema = <
+  Target extends "jsonSchema7" | "openApi3" = "jsonSchema7"
+>(
   schema: ZodSchema<any>,
-  options?: Partial<Options> | string
-): JsonSchema7Type & {
+  options?: Partial<Options<Target>> | string
+): (Target extends "jsonSchema7" ? JsonSchema7Type : object) & {
   $schema?: string;
-  definitions?: { [key: string]: JSONSchema7Type };
+  definitions?: {
+    [key: string]: Target extends "jsonSchema7" ? JSONSchema7Type : object;
+  };
 } => {
   const refs = getRefs(options);
 
@@ -41,7 +45,7 @@ const zodToJsonSchema = (
           }
     ) ?? {};
 
-  const combined: ReturnType<typeof zodToJsonSchema> =
+  const combined: ReturnType<typeof zodToJsonSchema<Target>> =
     name === undefined
       ? definitions
         ? {


### PR DESCRIPTION
Brings back genericism to not return strict JSON Schema draft 7 types when using "openApi3" as target.

Still no specific types for this as that would require a pretty big rewrite, so it's using `object` as it did before the API refactoring in 3.20.0

Should fix #35 