### PR TITLE
[WIP] Add OpenApi3 discriminated union support

### DIFF
--- a/test/parsers/union.test.ts
+++ b/test/parsers/union.test.ts
@@ -172,6 +172,53 @@ describe("Unions", () => {
     });
   });
 
+  it("should work with discriminated union type when using openapit3", () => {
+    const discUnion = z.discriminatedUnion("kek", [
+      z.object({ kek: z.literal("A"), lel: z.boolean() }),
+      z.object({ kek: z.literal("B"), lel: z.number() }),
+    ]);
+
+    const jsonSchema = parseUnionDef(discUnion._def, getRefs({
+      target: "openApi3",
+    }));
+
+    expect(jsonSchema).toStrictEqual({
+      oneOf: [
+        {
+          type: "object",
+          properties: {
+            kek: {
+              type: "string",
+              enum: ["A"],
+            },
+            lel: {
+              type: "boolean",
+            },
+          },
+          required: ["kek", "lel"],
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          properties: {
+            kek: {
+              type: "string",
+              enum: ["B"],
+            },
+            lel: {
+              type: "number",
+            },
+          },
+          required: ["kek", "lel"],
+          additionalProperties: false,
+        },
+      ],
+      discriminator: {
+        propertyName: "kek"
+      }
+    });
+  });
+
   it("should not ignore descriptions in literal unions", () => {
     expect([
       parseUnionDef(


### PR DESCRIPTION
This adds basic support for `oneOf` style discriminated unions, specifically for OpenAPI3. My main motivation has been to add discriminated union support to [trpc-openapi](https://github.com/jlalmes/trpc-openapi/issues/255), which depends on this library for parsing the zod objects. My understanding of json schema 7 is pretty shallow, so I created a separate type specifically for this case. I assume there's a much better way of doing what I'm doing, so I wanted to open this up to facilitate a conversation and find a path forward to adding true OpenApi 3 discriminated union support.