### PR TITLE
Adds length support to array definition

### DIFF
--- a/src/parsers/array.ts
+++ b/src/parsers/array.ts
@@ -39,6 +39,21 @@ export function parseArrayDef(def: ZodArrayDef, refs: Refs) {
       refs
     );
   }
-
+  if ( def.exactLength ) {
+    setResponseValueAndErrors(
+      res,
+      "minItems",
+      def.exactLength.value,
+      def.exactLength.message,
+      refs
+    );
+    setResponseValueAndErrors(
+      res,
+      "maxItems",
+      def.exactLength.value,
+      def.exactLength.message,
+      refs
+    );
+  }
   return res;
 }

--- a/test/parsers/array.test.ts
+++ b/test/parsers/array.test.ts
@@ -38,6 +38,21 @@ describe("Arrays and array validations", () => {
     };
     expect(parsedSchema).toStrictEqual(jsonSchema);
   });
+  it("should be possible to describe a string array with an exect length", () => {
+    const parsedSchema = parseArrayDef(
+      z.array(z.string()).length(5)._def,
+      getRefs()
+    );
+    const jsonSchema: JSONSchema7Type = {
+      type: "array",
+      items: {
+        type: "string",
+      },
+      minItems: 5,
+      maxItems: 5,
+    };
+    expect(parsedSchema).toStrictEqual(jsonSchema);
+  });
   it("should be possible to describe a string array with a minimum length of 1 by using nonempty", () => {
     const parsedSchema = parseArrayDef(
       z.array(z.any()).nonempty()._def,
@@ -78,6 +93,26 @@ describe("Arrays and array validations", () => {
       .array(z.any())
       .min(5, minLengthMessage)
       .max(10, maxLengthMessage);
+    const jsonParsedSchema = parseArrayDef(
+      zodArraySchema._def,
+      errorReferences()
+    );
+    expect(jsonParsedSchema).toStrictEqual(jsonSchema);
+  });
+  it("should include custom error messages for exactLength", () => {
+    const exactLengthMessage = "Must have exactly 5 items.";
+    const jsonSchema: JSONSchema7Type = {
+      type: "array",
+      minItems: 5,
+      maxItems: 5,
+      errorMessage: {
+        minItems: exactLengthMessage,
+        maxItems: exactLengthMessage,
+      },
+    };
+    const zodArraySchema = z
+      .array(z.any())
+      .length(5, exactLengthMessage)
     const jsonParsedSchema = parseArrayDef(
       zodArraySchema._def,
       errorReferences()


### PR DESCRIPTION
Currently, when converting a Zod schema of an array with a specified length, the resulting JSON schema loses this information:

```ts
import z from 'zod'
import { zodToJsonSchema } from "zod-to-json-schema";

const zodSchema = z.array(z.string()).length(3);
/*
ZodArray {
  spa: [Function: bound safeParseAsync] AsyncFunction,
  _def: {
    type: [Function (anonymous)],
    minLength: null,
    maxLength: null,
    exactLength: { value: 3, message: undefined },
    typeName: 'ZodArray'
  },
  ...
*/
 
const jsonSchema = zodToJsonSchema(zodSchema)
/*
{
  type: 'array',
  items: { type: 'string' },
  '$schema': 'http://json-schema.org/draft-07/schema#'
}
*/
```

This PR changes the array parser to handle an `exactLength` to set `minItems` and `maxItems` for the resulting JSON schema (similar to how it is already done for strings.)
 