### PR TITLE
fix: added discriminator for discriminatedUnions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2977,9 +2977,9 @@
       "dev": true
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3723,9 +3723,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -3994,9 +3994,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6491,9 +6491,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -7054,9 +7054,9 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "shebang-command": {
@@ -7241,9 +7241,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -16,6 +16,8 @@ export type Options<Target extends Targets = "jsonSchema7"> = {
   errorMessages: boolean;
   markdownDescription: boolean;
   emailStrategy: "format:email" | "format:idn-email" | "pattern:zod";
+  discriminator: boolean;
+  unionStrategy: "anyOf" | "oneOf";
 };
 
 export const defaultOptions: Options = {
@@ -32,6 +34,8 @@ export const defaultOptions: Options = {
   errorMessages: false,
   markdownDescription: false,
   emailStrategy: "format:email",
+  discriminator: false,
+  unionStrategy: "anyOf",
 };
 
 export const getDefaultOptions = <Target extends Targets>(

--- a/test/parsers/union.test.ts
+++ b/test/parsers/union.test.ts
@@ -172,6 +172,57 @@ describe("Unions", () => {
     });
   });
 
+  it("should work with discriminated union type, discriminator and oneOf", () => {
+    const discUnion = z.discriminatedUnion("kek", [
+      z.object({ kek: z.literal("A"), lel: z.boolean() }),
+      z.object({ kek: z.literal("B"), lel: z.number() }),
+    ]);
+
+    const jsonSchema = parseUnionDef(
+      discUnion._def,
+      getRefs({
+        unionStrategy: "oneOf",
+        discriminator: true,
+      })
+    );
+
+    expect(jsonSchema).toStrictEqual({
+      oneOf: [
+        {
+          type: "object",
+          properties: {
+            kek: {
+              type: "string",
+              const: "A",
+            },
+            lel: {
+              type: "boolean",
+            },
+          },
+          required: ["kek", "lel"],
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          properties: {
+            kek: {
+              type: "string",
+              const: "B",
+            },
+            lel: {
+              type: "number",
+            },
+          },
+          required: ["kek", "lel"],
+          additionalProperties: false,
+        },
+      ],
+      discriminator: {
+        propertyName: "kek",
+      },
+    });
+  });
+
   it("should not ignore descriptions in literal unions", () => {
     expect([
       parseUnionDef(


### PR DESCRIPTION
This PR adds support for OpenAPI `discriminator` keyword, which is part of Open API v3 and [supported by `ajv`](https://ajv.js.org/json-schema.html#discriminator) when using `oneOf` instead of `anyOf` for unions.