### PR TITLE
feat: added onParseDef callback

### DIFF
--- a/src/Options.ts
+++ b/src/Options.ts
@@ -18,7 +18,7 @@ export type Options<Target extends Targets = "jsonSchema7"> = {
   errorMessages: boolean;
   markdownDescription: boolean;
   emailStrategy: "format:email" | "format:idn-email" | "pattern:zod";
-  onParseDef: ((def: ZodTypeDef, refs: Refs, schema: JsonSchema7Type) => void) | undefined;
+  onParseDef: ((def: ZodTypeDef, refs: Refs, schema: JsonSchema7Type | undefined) => JsonSchema7Type | void) | undefined;
 };
 
 export const defaultOptions: Options = {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,4 +1,4 @@
-import { ZodSchema } from "zod";
+import { ZodSchema, type ZodTypeDef } from "zod";
 import type { Refs } from "./Refs";
 import type { JsonSchema7Type } from "./parseDef";
 
@@ -18,7 +18,7 @@ export type Options<Target extends Targets = "jsonSchema7"> = {
   errorMessages: boolean;
   markdownDescription: boolean;
   emailStrategy: "format:email" | "format:idn-email" | "pattern:zod";
-  onParseDef: ((refs: Refs, schema: JsonSchema7Type) => void) | undefined;
+  onParseDef: ((def: ZodTypeDef, refs: Refs, schema: JsonSchema7Type) => void) | undefined;
 };
 
 export const defaultOptions: Options = {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,6 +1,6 @@
 import { ZodSchema } from "zod";
-import { Refs } from "./Refs";
-import { JsonSchema7Type } from "./parseDef";
+import type { Refs } from "./Refs";
+import type { JsonSchema7Type } from "./parseDef";
 
 export type Targets = "jsonSchema7" | "jsonSchema2019-09" | "openApi3";
 

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,4 +1,6 @@
 import { ZodSchema } from "zod";
+import { Refs } from "./Refs";
+import { JsonSchema7Type } from "./parseDef";
 
 export type Targets = "jsonSchema7" | "jsonSchema2019-09" | "openApi3";
 
@@ -16,6 +18,7 @@ export type Options<Target extends Targets = "jsonSchema7"> = {
   errorMessages: boolean;
   markdownDescription: boolean;
   emailStrategy: "format:email" | "format:idn-email" | "pattern:zod";
+  onParseDef: ((refs: Refs, schema: JsonSchema7Type) => void) | undefined;
 };
 
 export const defaultOptions: Options = {
@@ -32,6 +35,7 @@ export const defaultOptions: Options = {
   errorMessages: false,
   markdownDescription: false,
   emailStrategy: "format:email",
+  onParseDef: undefined,
 };
 
 export const getDefaultOptions = <Target extends Targets>(

--- a/src/parseDef.ts
+++ b/src/parseDef.ts
@@ -98,7 +98,7 @@ export function parseDef(
   if (jsonSchema) {
     addMeta(def, refs, jsonSchema);
 
-    refs.onParseDef?.(refs, jsonSchema);
+    refs.onParseDef?.(def, refs, jsonSchema);
   }
 
   newItem.jsonSchema = jsonSchema;

--- a/src/parseDef.ts
+++ b/src/parseDef.ts
@@ -97,6 +97,8 @@ export function parseDef(
 
   if (jsonSchema) {
     addMeta(def, refs, jsonSchema);
+
+    refs.onParseDef?.(refs, jsonSchema);
   }
 
   newItem.jsonSchema = jsonSchema;

--- a/src/parseDef.ts
+++ b/src/parseDef.ts
@@ -94,16 +94,17 @@ export function parseDef(
   refs.seen.set(def, newItem);
 
   const jsonSchema = selectParser(def, (def as any).typeName, refs);
+  const fallbackJsonSchema = refs.onParseDef?.(def, refs, jsonSchema);
 
-  if (jsonSchema) {
-    addMeta(def, refs, jsonSchema);
+  const resolvedJsonSchema = jsonSchema ?? fallbackJsonSchema ?? undefined;
 
-    refs.onParseDef?.(def, refs, jsonSchema);
+  if (resolvedJsonSchema) {
+    addMeta(def, refs, resolvedJsonSchema);
   }
 
-  newItem.jsonSchema = jsonSchema;
+  newItem.jsonSchema = resolvedJsonSchema;
 
-  return jsonSchema;
+  return resolvedJsonSchema;
 }
 
 const get$ref = (

--- a/src/parseDef.ts
+++ b/src/parseDef.ts
@@ -93,10 +93,10 @@ export function parseDef(
 
   refs.seen.set(def, newItem);
 
-  const jsonSchema = selectParser(def, (def as any).typeName, refs);
-  const fallbackJsonSchema = refs.onParseDef?.(def, refs, jsonSchema);
+  const defaultJsonSchema = selectParser(def, (def as any).typeName, refs);
+  const manualJsonSchema = refs.onParseDef?.(def, refs, defaultJsonSchema);
 
-  const resolvedJsonSchema = jsonSchema ?? fallbackJsonSchema ?? undefined;
+  const resolvedJsonSchema = manualJsonSchema ?? defaultJsonSchema ?? undefined;
 
   if (resolvedJsonSchema) {
     addMeta(def, refs, resolvedJsonSchema);


### PR DESCRIPTION
This is to enable callbacks in the parsing of Zod schemas. The use-case is that I'm doing custom validation of the Zod schema (making sure there's a description, that no unsupported types are used, etc).

Let me know if you want to see the API look any different with this.