### PR TITLE
Cannot read properties of undefined (reading '_def')

### DIFF
--- a/src/parsers/array.ts
+++ b/src/parsers/array.ts
@@ -15,7 +15,7 @@ export function parseArrayDef(def: ZodArrayDef, refs: Refs) {
   const res: JsonSchema7ArrayType = {
     type: "array",
   };
-  if (def.type?._def?.typeName !== ZodFirstPartyTypeKind.ZodAny) {
+  if (def.type?._def && def.type?._def?.typeName !== ZodFirstPartyTypeKind.ZodAny) {
     res.items = parseDef(def.type._def, {
       ...refs,
       currentPath: [...refs.currentPath, "items"],


### PR DESCRIPTION
Hello! I just started using [trpc-openapi](https://github.com/jlalmes/trpc-openapi) which uses this package.

I observed an error with array definitions:
```
backend:dev: Recursive reference detected at #/properties/description/anyOf/4/additionalProperties/anyOf/1! Defaulting to any
backend:dev: Recursive reference detected at #/properties/description/anyOf/5/items! Defaulting to any
backend:dev: Recursive reference detected at #/properties/description/anyOf/4/additionalProperties/anyOf/1! Defaulting to any
backend:dev: Recursive reference detected at #/properties/description/anyOf/5/items! Defaulting to any
backend:dev: Recursive reference detected at #/properties/description/anyOf/4/additionalProperties/anyOf/1! Defaulting to any
backend:dev: Recursive reference detected at #/properties/description/anyOf/5/items! Defaulting to any
backend:dev: Recursive reference detected at #/properties/description/anyOf/4/additionalProperties/anyOf/1! Defaulting to any
backend:dev: Recursive reference detected at #/properties/description/anyOf/5/items! Defaulting to any
backend:dev: Waiting for the debugger to disconnect...
backend:dev: /codetrackr/node_modules/.pnpm/zod-to-json-schema@3.23.2_zod@3.23.8/node_modules/zod-to-json-schema/dist/cjs/parsers/array.js:12
backend:dev:         res.items = (0, parseDef_js_1.parseDef)(def.type._def, {
backend:dev:                                                          ^
backend:dev: 
backend:dev: TypeError: [query.teams.] - Cannot read properties of undefined (reading '_def')
backend:dev:     at parseArrayDef (/codetrackr/node_modules/.pnpm/zod-to-json-schema@3.23.2_zod@3.23.8/node_modules/zod-to-json-schema/dist/cjs/parsers/array.js:12:58)
backend:dev:     at selectParser (/codetrackr/node_modules/.pnpm/zod-to-json-schema@3.23.2_zod@3.23.8/node_modules/zod-to-json-schema/dist/cjs/parseDef.js:104:49)
backend:dev:     at parseDef (/codetrackr/node_modules/.pnpm/zod-to-json-schema@3.23.2_zod@3.23.8/node_modules/zod-to-json-schema/dist/cjs/parseDef.js:52:24)
backend:dev:     at Object.entries.reduce.properties (/codetrackr/node_modules/.pnpm/zod-to-json-schema@3.23.2_zod@3.23.8/node_modules/zod-to-json-schema/dist/cjs/parsers/object.js:83:58)
backend:dev:     at Array.reduce (<anonymous>)
backend:dev:     at parseObjectDef (/codetrackr/node_modules/.pnpm/zod-to-json-schema@3.23.2_zod@3.23.8/node_modules/zod-to-json-schema/dist/cjs/parsers/object.js:80:40)
backend:dev:     at selectParser (/codetrackr/node_modules/.pnpm/zod-to-json-schema@3.23.2_zod@3.23.8/node_modules/zod-to-json-schema/dist/cjs/parseDef.js:92:51)
backend:dev:     at parseDef (/codetrackr/node_modules/.pnpm/zod-to-json-schema@3.23.2_zod@3.23.8/node_modules/zod-to-json-schema/dist/cjs/parseDef.js:52:24)
backend:dev:     at Object.entries.reduce.properties (/codetrackr/node_modules/.pnpm/zod-to-json-schema@3.23.2_zod@3.23.8/node_modules/zod-to-json-schema/dist/cjs/parsers/object.js:83:58)
backend:dev:     at Array.reduce (<anonymous>)
backend:dev: 
backend:dev: Node.js v19.9.0
```

This fixes this issue and I didn't observe any discrepancies in the result.