### PR TITLE
Add json schema readonly attribute

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,3 @@
-{}
+{
+  "trailingComma": "all"
+}

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -33,12 +33,13 @@ export type Options<Target extends Targets = "jsonSchema7"> = {
   applyRegexFlags: boolean;
   emailStrategy: "format:email" | "format:idn-email" | "pattern:zod";
   base64Strategy: "format:binary" | "contentEncoding:base64" | "pattern:zod";
-  nameStrategy: "ref" | "title",
+  nameStrategy: "ref" | "title";
   override?: (
     def: ZodTypeDef,
     refs: Refs,
     seen: Seen | undefined,
     forceResolution?: boolean,
+    readonly?: boolean,
   ) => JsonSchema7Type | undefined | typeof ignoreOverride;
 };
 
@@ -61,7 +62,7 @@ export const defaultOptions: Options = {
   applyRegexFlags: false,
   emailStrategy: "format:email",
   base64Strategy: "contentEncoding:base64",
-  nameStrategy: "ref"
+  nameStrategy: "ref",
 };
 
 export const getDefaultOptions = <Target extends Targets>(

--- a/src/parsers/readonly.ts
+++ b/src/parsers/readonly.ts
@@ -3,5 +3,5 @@ import { parseDef } from "../parseDef.js";
 import { Refs } from "../Refs.js";
 
 export const parseReadonlyDef = (def: ZodReadonlyDef<any>, refs: Refs) => {
-  return parseDef(def.innerType._def, refs);
+  return parseDef(def.innerType._def, refs, false, true);
 };

--- a/src/parsers/string.ts
+++ b/src/parsers/string.ts
@@ -35,7 +35,10 @@ export const zodPatterns = {
    */
   emoji: () => {
     if (emojiRegex === undefined) {
-      emojiRegex = RegExp("^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$", "u");
+      emojiRegex = RegExp(
+        "^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$",
+        "u"
+      );
     }
     return emojiRegex;
   },
@@ -85,7 +88,7 @@ export type JsonSchema7StringType = {
 
 export function parseStringDef(
   def: ZodStringDef,
-  refs: Refs,
+  refs: Refs
 ): JsonSchema7StringType {
   const res: JsonSchema7StringType = {
     type: "string",
@@ -108,7 +111,7 @@ export function parseStringDef(
               ? Math.max(res.minLength, check.value)
               : check.value,
             check.message,
-            refs,
+            refs
           );
           break;
         case "max":
@@ -119,7 +122,7 @@ export function parseStringDef(
               ? Math.min(res.maxLength, check.value)
               : check.value,
             check.message,
-            refs,
+            refs
           );
 
           break;
@@ -157,7 +160,7 @@ export function parseStringDef(
             res,
             RegExp(`^${processPattern(check.value)}`),
             check.message,
-            refs,
+            refs
           );
           break;
         case "endsWith":
@@ -165,7 +168,7 @@ export function parseStringDef(
             res,
             RegExp(`${processPattern(check.value)}$`),
             check.message,
-            refs,
+            refs
           );
           break;
 
@@ -189,7 +192,7 @@ export function parseStringDef(
               ? Math.max(res.minLength, check.value)
               : check.value,
             check.message,
-            refs,
+            refs
           );
           setResponseValueAndErrors(
             res,
@@ -198,7 +201,7 @@ export function parseStringDef(
               ? Math.min(res.maxLength, check.value)
               : check.value,
             check.message,
-            refs,
+            refs
           );
           break;
         case "includes": {
@@ -206,7 +209,7 @@ export function parseStringDef(
             res,
             RegExp(processPattern(check.value)),
             check.message,
-            refs,
+            refs
           );
           break;
         }
@@ -239,7 +242,7 @@ export function parseStringDef(
                 "contentEncoding",
                 "base64",
                 check.message,
-                refs,
+                refs
               );
               break;
             }
@@ -277,7 +280,7 @@ const addFormat = (
   schema: JsonSchema7StringType,
   value: Required<JsonSchema7StringType>["format"],
   message: string | undefined,
-  refs: Refs,
+  refs: Refs
 ) => {
   if (schema.format || schema.anyOf?.some((x) => x.format)) {
     if (!schema.anyOf) {
@@ -315,7 +318,7 @@ const addPattern = (
   schema: JsonSchema7StringType,
   regex: RegExp | (() => RegExp),
   message: string | undefined,
-  refs: Refs,
+  refs: Refs
 ) => {
   if (schema.pattern || schema.allOf?.some((x) => x.pattern)) {
     if (!schema.allOf) {
@@ -350,14 +353,18 @@ const addPattern = (
       "pattern",
       processRegExp(regex, refs),
       message,
-      refs,
+      refs
     );
   }
 };
 
 // Mutate z.string.regex() in a best attempt to accommodate for regex flags when applyRegexFlags is true
-const processRegExp = (regexOrFunction: RegExp | (() => RegExp), refs: Refs): string => {
-  const regex = typeof regexOrFunction === "function" ? regexOrFunction() : regexOrFunction;
+const processRegExp = (
+  regexOrFunction: RegExp | (() => RegExp),
+  refs: Refs
+): string => {
+  const regex =
+    typeof regexOrFunction === "function" ? regexOrFunction() : regexOrFunction;
   if (!refs.applyRegexFlags || !regex.flags) return regex.source;
 
   // Currently handled flags
@@ -433,8 +440,8 @@ const processRegExp = (regexOrFunction: RegExp | (() => RegExp), refs: Refs): st
   } catch {
     console.warn(
       `Could not convert regex pattern at ${refs.currentPath.join(
-        "/",
-      )} to a flag-independent form! Falling back to the flag-ignorant source`,
+        "/"
+      )} to a flag-independent form! Falling back to the flag-ignorant source`
     );
     return regex.source;
   }

--- a/test/parseDef.test.ts
+++ b/test/parseDef.test.ts
@@ -185,6 +185,7 @@ suite("Basic parsing", (test) => {
       type: "object",
       properties: {},
       additionalProperties: false,
+      readOnly: true,
     };
     assert(parsedSchema, jsonSchema);
   });

--- a/test/parsers/readonly.test.ts
+++ b/test/parsers/readonly.test.ts
@@ -5,11 +5,29 @@ import { getRefs } from "../../src/Refs.js";
 import { suite } from "../suite.js";
 suite("readonly", (test) => {
   test("should be possible to use readonly", (assert) => {
-    const parsedSchema = parseReadonlyDef(z.object({}).readonly()._def, getRefs());
+    const parsedSchema = parseReadonlyDef(
+      z.object({}).readonly()._def,
+      getRefs(),
+    );
     const jsonSchema: JSONSchema7Type = {
       type: "object",
       properties: {},
       additionalProperties: false,
+      readOnly: true,
+    };
+    assert(parsedSchema, jsonSchema);
+  });
+  test("should be possible to use readonly on strings", (assert) => {
+    const parsedSchema = parseReadonlyDef(
+      z.object({ test: z.string().readonly() }).readonly()._def,
+      getRefs(),
+    );
+    const jsonSchema: JSONSchema7Type = {
+      type: "object",
+      properties: { test: { type: "string", readOnly: true } },
+      required: ["test"],
+      additionalProperties: false,
+      readOnly: true,
     };
     assert(parsedSchema, jsonSchema);
   });


### PR DESCRIPTION
I would like to include the `readOnly` attribute. I know this is a pretty rudimentary set of changes but please let me know what extra tests are needed in order to get integrated?

Here are some details about the readOnly attribute:

https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-02#section-9.4

Here is a discussion about uses of read only:

https://stackoverflow.com/questions/60840385/are-there-more-examples-of-readonly-being-used-at-several-levels-of-a-schema-to