### PR TITLE
Fix #151-  Missing .js extension for /branded import

### DIFF
--- a/src/parsers/record.ts
+++ b/src/parsers/record.ts
@@ -9,7 +9,7 @@ import { Refs } from "../Refs.js";
 import { JsonSchema7EnumType } from "./enum.js";
 import { JsonSchema7ObjectType } from "./object.js";
 import { JsonSchema7StringType, parseStringDef } from "./string.js";
-import { parseBrandedDef } from "./branded";
+import { parseBrandedDef } from "./branded.js";
 
 type JsonSchema7RecordPropertyNamesType =
   | Omit<JsonSchema7StringType, "type">


### PR DESCRIPTION
As reported in #151 , the last published version is missing a `.js` extension when importing from `"./branded"`

https://github.com/StefanTerdell/zod-to-json-schema/commit/ccf1cbf61c415ebb4b8252736979d5632662c208#diff-618e37ffb2ed63e6b03a60dd390c5ce5fb8c6bd8d57572104c5080948c4437f6R12

