### PR TITLE
Add 2020-12 support

### DIFF
--- a/src/Options.ts
+++ b/src/Options.ts
@@ -2,7 +2,7 @@ import { ZodSchema, ZodTypeDef } from "zod";
 import { Refs, Seen } from "./Refs";
 import { JsonSchema7Type } from "./parseDef";
 
-export type Targets = "jsonSchema7" | "jsonSchema2019-09" | "openApi3" | "openAi";
+export type Targets = "jsonSchema7" | "jsonSchema2019-09" | "jsonSchema2020-12" | "openApi3" | "openAi";
 
 export type DateStrategy =
   | "format:date-time"

--- a/src/parsers/intersection.ts
+++ b/src/parsers/intersection.ts
@@ -33,7 +33,7 @@ export function parseIntersectionDef(
   let unevaluatedProperties:
     | Pick<JsonSchema7AllOfType, "unevaluatedProperties">
     | undefined =
-    refs.target === "jsonSchema2019-09"
+    refs.target === "jsonSchema2019-09" || refs.target === "jsonSchema2020-12"
       ? { unevaluatedProperties: false }
       : undefined;
 

--- a/src/zodToJsonSchema.ts
+++ b/src/zodToJsonSchema.ts
@@ -105,7 +105,7 @@ const zodToJsonSchema = <Target extends Targets = "jsonSchema7">(
       ("type" in combined && Array.isArray(combined.type)))
   ) {
     console.warn(
-      "Warning: OpenAI may not support schemas with unions as roots! Try wrapping it in an object property."
+      "Warning: OpenAI may not support schemas with unions as roots! Try wrapping it in an object property.",
     );
   }
 

--- a/src/zodToJsonSchema.ts
+++ b/src/zodToJsonSchema.ts
@@ -13,7 +13,9 @@ const zodToJsonSchema = <Target extends Targets = "jsonSchema7">(
       ? JsonSchema7Type
       : Target extends "jsonSchema2019-09"
         ? JsonSchema7Type
-        : object;
+        : Target extends "jsonSchema2020-12"
+          ? JsonSchema7Type
+          : object;
   };
 } => {
   const refs = getRefs(options);
@@ -91,6 +93,8 @@ const zodToJsonSchema = <Target extends Targets = "jsonSchema7">(
     combined.$schema = "http://json-schema.org/draft-07/schema#";
   } else if (refs.target === "jsonSchema2019-09" || refs.target === "openAi") {
     combined.$schema = "https://json-schema.org/draft/2019-09/schema#";
+  } else if (refs.target === "jsonSchema2020-12") {
+    combined.$schema = "https://json-schema.org/draft/2020-12/schema#";
   }
 
   if (
@@ -101,7 +105,7 @@ const zodToJsonSchema = <Target extends Targets = "jsonSchema7">(
       ("type" in combined && Array.isArray(combined.type)))
   ) {
     console.warn(
-      "Warning: OpenAI may not support schemas with unions as roots! Try wrapping it in an object property.",
+      "Warning: OpenAI may not support schemas with unions as roots! Try wrapping it in an object property."
     );
   }
 

--- a/test/allParsers.test.ts
+++ b/test/allParsers.test.ts
@@ -664,7 +664,16 @@ suite("All Parsers tests", (test) => {
       },
       description: "watup",
     };
-    assert(jsonSchema, expectedOutput);
+  });
+
+  test("2020-12 should produce correct schema name", (assert) => {
+    const jsonSchema2020 = zodToJsonSchema(allParsersSchema, {
+      target: "jsonSchema2020-12",
+    });
+
+    const expectedSchemaValue = "https://json-schema.org/draft/2020-12/schema#";
+    //
+    assert(jsonSchema2020.$schema, expectedSchemaValue);
   });
 
   test("With OpenAPI schema target, should produce valid Open API schema", (assert) => {

--- a/test/allParsers.test.ts
+++ b/test/allParsers.test.ts
@@ -664,15 +664,15 @@ suite("All Parsers tests", (test) => {
       },
       description: "watup",
     };
+    assert(jsonSchema, expectedOutput);
   });
 
   test("2020-12 should produce correct schema name", (assert) => {
     const jsonSchema2020 = zodToJsonSchema(allParsersSchema, {
       target: "jsonSchema2020-12",
     });
-
     const expectedSchemaValue = "https://json-schema.org/draft/2020-12/schema#";
-    //
+
     assert(jsonSchema2020.$schema, expectedSchemaValue);
   });
 


### PR DESCRIPTION
This change adds compatibility for parsers which require the 2020-12 schema name.  (The popular library AJV, when parsing 2020 schemas, currently throws an error for zod-to-json-schema output since there's no 2020-12 option.)  

This change also resolves user confusion about why the "latest version" of the JSON Schema spec isn't supported.

This code change mostly just entails returning the 2020-12 schema name.

### Usage:

```typescript
const jsonSchema = zodToJsonSchema(zodSchema, {
  target: "jsonSchema2020-12",
});
```

### Tasks:
[x] Searched code for any references to 2019
[x] Added 2020-12 test, and ran test suite

### More info:
https://github.com/StefanTerdell/zod-to-json-schema/issues/160

