### PR TITLE
Fix circular dependencies

### DIFF
--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,6 +1,6 @@
 import { ZodSchema, ZodTypeDef } from "zod";
 import { Refs, Seen } from "./Refs";
-import { JsonSchema7Type } from "./parseDef";
+import { JsonSchema7Type } from "./parseTypes";
 
 export type Targets = "jsonSchema7" | "jsonSchema2019-09" | "openApi3" | "openAi";
 

--- a/src/Refs.ts
+++ b/src/Refs.ts
@@ -1,6 +1,6 @@
 import { ZodTypeDef } from "zod";
 import { getDefaultOptions, Options, Targets } from "./Options.js";
-import { JsonSchema7Type } from "./parseDef.js";
+import { JsonSchema7Type } from "./parseTypes.js";
 
 export type Refs = {
   seen: Map<ZodTypeDef, Seen>;

--- a/src/errorMessages.ts
+++ b/src/errorMessages.ts
@@ -1,4 +1,4 @@
-import { JsonSchema7TypeUnion } from "./parseDef.js";
+import { JsonSchema7TypeUnion } from "./parseTypes.js";
 import { Refs } from "./Refs.js";
 
 export type ErrorMessages<

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export * from "./parsers/tuple.js";
 export * from "./parsers/undefined.js";
 export * from "./parsers/union.js";
 export * from "./parsers/unknown.js";
+export * from "./selectParser.js";
 export * from "./zodToJsonSchema.js";
 import { zodToJsonSchema } from "./zodToJsonSchema.js";
 export default zodToJsonSchema;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from "./Options.js";
 export * from "./Refs.js";
 export * from "./errorMessages.js";
 export * from "./parseDef.js";
+export * from "./parseTypes.js";
 export * from "./parsers/any.js";
 export * from "./parsers/array.js";
 export * from "./parsers/bigint.js";

--- a/src/parseDef.ts
+++ b/src/parseDef.ts
@@ -1,37 +1,8 @@
-import { ZodFirstPartyTypeKind, ZodTypeDef } from "zod";
-import { parseAnyDef } from "./parsers/any.js";
-import { parseArrayDef } from "./parsers/array.js";
-import { parseBigintDef } from "./parsers/bigint.js";
-import { parseBooleanDef } from "./parsers/boolean.js";
-import { parseBrandedDef } from "./parsers/branded.js";
-import { parseCatchDef } from "./parsers/catch.js";
-import { parseDateDef } from "./parsers/date.js";
-import { parseDefaultDef } from "./parsers/default.js";
-import { parseEffectsDef } from "./parsers/effects.js";
-import { parseEnumDef } from "./parsers/enum.js";
-import {parseIntersectionDef } from "./parsers/intersection.js";
-import { parseLiteralDef } from "./parsers/literal.js";
-import { parseMapDef } from "./parsers/map.js";
-import { parseNativeEnumDef } from "./parsers/nativeEnum.js";
-import { parseNeverDef } from "./parsers/never.js";
-import { parseNullDef } from "./parsers/null.js";
-import { parseNullableDef } from "./parsers/nullable.js";
-import { parseNumberDef } from "./parsers/number.js";
-import { parseObjectDef } from "./parsers/object.js";
-import { parseOptionalDef } from "./parsers/optional.js";
-import { parsePipelineDef } from "./parsers/pipeline.js";
-import { parsePromiseDef } from "./parsers/promise.js";
-import { parseRecordDef } from "./parsers/record.js";
-import { parseSetDef } from "./parsers/set.js";
-import { parseStringDef } from "./parsers/string.js";
-import { parseTupleDef } from "./parsers/tuple.js";
-import { parseUndefinedDef} from "./parsers/undefined.js";
-import { parseUnionDef } from "./parsers/union.js";
-import {  parseUnknownDef } from "./parsers/unknown.js";
+import { ZodTypeDef } from "zod";
 import { Refs, Seen } from "./Refs.js";
-import { parseReadonlyDef } from "./parsers/readonly.js";
 import { ignoreOverride } from "./Options.js";
 import { JsonSchema7Type } from "./parseTypes.js";
+import { selectParser } from "./selectParser.js";
 
 export function parseDef(
   def: ZodTypeDef,
@@ -65,7 +36,12 @@ export function parseDef(
 
   refs.seen.set(def, newItem);
 
-  const jsonSchema = selectParser(def, (def as any).typeName, refs);
+  let jsonSchema = selectParser(def, (def as any).typeName, refs);
+
+  // If the return was strictly null, then it's a call to parseDef (recursive)
+  if (jsonSchema === null) {
+    jsonSchema = parseDef((def as any).getter()._def, refs)
+  }
 
   if (jsonSchema) {
     addMeta(def, refs, jsonSchema);
@@ -116,86 +92,6 @@ const getRelativePath = (pathA: string[], pathB: string[]) => {
     if (pathA[i] !== pathB[i]) break;
   }
   return [(pathA.length - i).toString(), ...pathB.slice(i)].join("/");
-};
-
-const selectParser = (
-  def: any,
-  typeName: ZodFirstPartyTypeKind,
-  refs: Refs,
-): JsonSchema7Type | undefined => {
-  switch (typeName) {
-    case ZodFirstPartyTypeKind.ZodString:
-      return parseStringDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodNumber:
-      return parseNumberDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodObject:
-      return parseObjectDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodBigInt:
-      return parseBigintDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodBoolean:
-      return parseBooleanDef();
-    case ZodFirstPartyTypeKind.ZodDate:
-      return parseDateDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodUndefined:
-      return parseUndefinedDef();
-    case ZodFirstPartyTypeKind.ZodNull:
-      return parseNullDef(refs);
-    case ZodFirstPartyTypeKind.ZodArray:
-      return parseArrayDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodUnion:
-    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
-      return parseUnionDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodIntersection:
-      return parseIntersectionDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodTuple:
-      return parseTupleDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodRecord:
-      return parseRecordDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodLiteral:
-      return parseLiteralDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodEnum:
-      return parseEnumDef(def);
-    case ZodFirstPartyTypeKind.ZodNativeEnum:
-      return parseNativeEnumDef(def);
-    case ZodFirstPartyTypeKind.ZodNullable:
-      return parseNullableDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodOptional:
-      return parseOptionalDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodMap:
-      return parseMapDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodSet:
-      return parseSetDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodLazy:
-      return parseDef(def.getter()._def, refs);
-    case ZodFirstPartyTypeKind.ZodPromise:
-      return parsePromiseDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodNaN:
-    case ZodFirstPartyTypeKind.ZodNever:
-      return parseNeverDef();
-    case ZodFirstPartyTypeKind.ZodEffects:
-      return parseEffectsDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodAny:
-      return parseAnyDef();
-    case ZodFirstPartyTypeKind.ZodUnknown:
-      return parseUnknownDef();
-    case ZodFirstPartyTypeKind.ZodDefault:
-      return parseDefaultDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodBranded:
-      return parseBrandedDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodReadonly:
-      return parseReadonlyDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodCatch:
-      return parseCatchDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodPipeline:
-      return parsePipelineDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodFunction:
-    case ZodFirstPartyTypeKind.ZodVoid:
-    case ZodFirstPartyTypeKind.ZodSymbol:
-      return undefined;
-    default:
-      /* c8 ignore next */
-      return ((_: never) => undefined)(typeName);
-  }
 };
 
 const addMeta = (

--- a/src/parseDef.ts
+++ b/src/parseDef.ts
@@ -1,84 +1,37 @@
 import { ZodFirstPartyTypeKind, ZodTypeDef } from "zod";
-import { JsonSchema7AnyType, parseAnyDef } from "./parsers/any.js";
-import { JsonSchema7ArrayType, parseArrayDef } from "./parsers/array.js";
-import { JsonSchema7BigintType, parseBigintDef } from "./parsers/bigint.js";
-import { JsonSchema7BooleanType, parseBooleanDef } from "./parsers/boolean.js";
+import { parseAnyDef } from "./parsers/any.js";
+import { parseArrayDef } from "./parsers/array.js";
+import { parseBigintDef } from "./parsers/bigint.js";
+import { parseBooleanDef } from "./parsers/boolean.js";
 import { parseBrandedDef } from "./parsers/branded.js";
 import { parseCatchDef } from "./parsers/catch.js";
-import { JsonSchema7DateType, parseDateDef } from "./parsers/date.js";
+import { parseDateDef } from "./parsers/date.js";
 import { parseDefaultDef } from "./parsers/default.js";
 import { parseEffectsDef } from "./parsers/effects.js";
-import { JsonSchema7EnumType, parseEnumDef } from "./parsers/enum.js";
-import {
-  JsonSchema7AllOfType,
-  parseIntersectionDef,
-} from "./parsers/intersection.js";
-import { JsonSchema7LiteralType, parseLiteralDef } from "./parsers/literal.js";
-import { JsonSchema7MapType, parseMapDef } from "./parsers/map.js";
-import {
-  JsonSchema7NativeEnumType,
-  parseNativeEnumDef,
-} from "./parsers/nativeEnum.js";
-import { JsonSchema7NeverType, parseNeverDef } from "./parsers/never.js";
-import { JsonSchema7NullType, parseNullDef } from "./parsers/null.js";
-import {
-  JsonSchema7NullableType,
-  parseNullableDef,
-} from "./parsers/nullable.js";
-import { JsonSchema7NumberType, parseNumberDef } from "./parsers/number.js";
-import { JsonSchema7ObjectType, parseObjectDef } from "./parsers/object.js";
+import { parseEnumDef } from "./parsers/enum.js";
+import {parseIntersectionDef } from "./parsers/intersection.js";
+import { parseLiteralDef } from "./parsers/literal.js";
+import { parseMapDef } from "./parsers/map.js";
+import { parseNativeEnumDef } from "./parsers/nativeEnum.js";
+import { parseNeverDef } from "./parsers/never.js";
+import { parseNullDef } from "./parsers/null.js";
+import { parseNullableDef } from "./parsers/nullable.js";
+import { parseNumberDef } from "./parsers/number.js";
+import { parseObjectDef } from "./parsers/object.js";
 import { parseOptionalDef } from "./parsers/optional.js";
 import { parsePipelineDef } from "./parsers/pipeline.js";
 import { parsePromiseDef } from "./parsers/promise.js";
-import { JsonSchema7RecordType, parseRecordDef } from "./parsers/record.js";
-import { JsonSchema7SetType, parseSetDef } from "./parsers/set.js";
-import { JsonSchema7StringType, parseStringDef } from "./parsers/string.js";
-import { JsonSchema7TupleType, parseTupleDef } from "./parsers/tuple.js";
-import {
-  JsonSchema7UndefinedType,
-  parseUndefinedDef,
-} from "./parsers/undefined.js";
-import { JsonSchema7UnionType, parseUnionDef } from "./parsers/union.js";
-import { JsonSchema7UnknownType, parseUnknownDef } from "./parsers/unknown.js";
+import { parseRecordDef } from "./parsers/record.js";
+import { parseSetDef } from "./parsers/set.js";
+import { parseStringDef } from "./parsers/string.js";
+import { parseTupleDef } from "./parsers/tuple.js";
+import { parseUndefinedDef} from "./parsers/undefined.js";
+import { parseUnionDef } from "./parsers/union.js";
+import {  parseUnknownDef } from "./parsers/unknown.js";
 import { Refs, Seen } from "./Refs.js";
 import { parseReadonlyDef } from "./parsers/readonly.js";
 import { ignoreOverride } from "./Options.js";
-
-type JsonSchema7RefType = { $ref: string };
-type JsonSchema7Meta = {
-  title?: string;
-  default?: any;
-  description?: string;
-  markdownDescription?: string;
-};
-
-export type JsonSchema7TypeUnion =
-  | JsonSchema7StringType
-  | JsonSchema7ArrayType
-  | JsonSchema7NumberType
-  | JsonSchema7BigintType
-  | JsonSchema7BooleanType
-  | JsonSchema7DateType
-  | JsonSchema7EnumType
-  | JsonSchema7LiteralType
-  | JsonSchema7NativeEnumType
-  | JsonSchema7NullType
-  | JsonSchema7NumberType
-  | JsonSchema7ObjectType
-  | JsonSchema7RecordType
-  | JsonSchema7TupleType
-  | JsonSchema7UnionType
-  | JsonSchema7UndefinedType
-  | JsonSchema7RefType
-  | JsonSchema7NeverType
-  | JsonSchema7MapType
-  | JsonSchema7AnyType
-  | JsonSchema7NullableType
-  | JsonSchema7AllOfType
-  | JsonSchema7UnknownType
-  | JsonSchema7SetType;
-
-export type JsonSchema7Type = JsonSchema7TypeUnion & JsonSchema7Meta;
+import { JsonSchema7Type } from "./parseTypes.js";
 
 export function parseDef(
   def: ZodTypeDef,
@@ -128,8 +81,8 @@ const get$ref = (
   refs: Refs,
 ):
   | {
-      $ref: string;
-    }
+    $ref: string;
+  }
   | {}
   | undefined => {
   switch (refs.$refStrategy) {

--- a/src/parseTypes.ts
+++ b/src/parseTypes.ts
@@ -1,0 +1,66 @@
+import { JsonSchema7AnyType } from "./parsers/any.js";
+import { JsonSchema7ArrayType } from "./parsers/array.js";
+import { JsonSchema7BigintType } from "./parsers/bigint.js";
+import { JsonSchema7BooleanType } from "./parsers/boolean.js";
+import { JsonSchema7DateType } from "./parsers/date.js";
+import { JsonSchema7EnumType } from "./parsers/enum.js";
+import {
+    JsonSchema7AllOfType
+} from "./parsers/intersection.js";
+import { JsonSchema7LiteralType } from "./parsers/literal.js";
+import { JsonSchema7MapType } from "./parsers/map.js";
+import {
+    JsonSchema7NativeEnumType,
+} from "./parsers/nativeEnum.js";
+import { JsonSchema7NeverType } from "./parsers/never.js";
+import { JsonSchema7NullType } from "./parsers/null.js";
+import {
+    JsonSchema7NullableType,
+} from "./parsers/nullable.js";
+import { JsonSchema7NumberType } from "./parsers/number.js";
+import { JsonSchema7ObjectType } from "./parsers/object.js";
+import { JsonSchema7RecordType } from "./parsers/record.js";
+import { JsonSchema7SetType } from "./parsers/set.js";
+import { JsonSchema7StringType } from "./parsers/string.js";
+import { JsonSchema7TupleType } from "./parsers/tuple.js";
+import {
+    JsonSchema7UndefinedType
+} from "./parsers/undefined.js";
+import { JsonSchema7UnionType } from "./parsers/union.js";
+import { JsonSchema7UnknownType } from "./parsers/unknown.js";
+
+type JsonSchema7RefType = { $ref: string };
+type JsonSchema7Meta = {
+    title?: string;
+    default?: any;
+    description?: string;
+    markdownDescription?: string;
+};
+
+export type JsonSchema7TypeUnion =
+    | JsonSchema7StringType
+    | JsonSchema7ArrayType
+    | JsonSchema7NumberType
+    | JsonSchema7BigintType
+    | JsonSchema7BooleanType
+    | JsonSchema7DateType
+    | JsonSchema7EnumType
+    | JsonSchema7LiteralType
+    | JsonSchema7NativeEnumType
+    | JsonSchema7NullType
+    | JsonSchema7NumberType
+    | JsonSchema7ObjectType
+    | JsonSchema7RecordType
+    | JsonSchema7TupleType
+    | JsonSchema7UnionType
+    | JsonSchema7UndefinedType
+    | JsonSchema7RefType
+    | JsonSchema7NeverType
+    | JsonSchema7MapType
+    | JsonSchema7AnyType
+    | JsonSchema7NullableType
+    | JsonSchema7AllOfType
+    | JsonSchema7UnknownType
+    | JsonSchema7SetType;
+
+export type JsonSchema7Type = JsonSchema7TypeUnion & JsonSchema7Meta;

--- a/src/parsers/array.ts
+++ b/src/parsers/array.ts
@@ -1,6 +1,7 @@
 import { ZodArrayDef, ZodFirstPartyTypeKind } from "zod";
 import { ErrorMessages, setResponseValueAndErrors } from "../errorMessages.js";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 
 export type JsonSchema7ArrayType = {

--- a/src/parsers/default.ts
+++ b/src/parsers/default.ts
@@ -1,5 +1,6 @@
 import { ZodDefaultDef } from "zod";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 
 export function parseDefaultDef(

--- a/src/parsers/effects.ts
+++ b/src/parsers/effects.ts
@@ -1,5 +1,6 @@
 import { ZodEffectsDef } from "zod";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 
 export function parseEffectsDef(

--- a/src/parsers/intersection.ts
+++ b/src/parsers/intersection.ts
@@ -1,5 +1,6 @@
 import { ZodIntersectionDef } from "zod";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 import { JsonSchema7StringType } from "./string.js";
 

--- a/src/parsers/map.ts
+++ b/src/parsers/map.ts
@@ -1,5 +1,6 @@
 import { ZodMapDef } from "zod";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 import { JsonSchema7RecordType, parseRecordDef } from "./record.js";
 

--- a/src/parsers/nullable.ts
+++ b/src/parsers/nullable.ts
@@ -1,5 +1,6 @@
 import { ZodNullableDef } from "zod";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 import { JsonSchema7NullType } from "./null.js";
 import { primitiveMappings } from "./union.js";

--- a/src/parsers/object.ts
+++ b/src/parsers/object.ts
@@ -1,5 +1,6 @@
 import { ZodObjectDef, ZodOptional } from "zod";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 
 function decideAdditionalProperties(def: ZodObjectDef, refs: Refs) {

--- a/src/parsers/optional.ts
+++ b/src/parsers/optional.ts
@@ -1,5 +1,6 @@
 import { ZodOptionalDef } from "zod";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 
 export const parseOptionalDef = (

--- a/src/parsers/pipeline.ts
+++ b/src/parsers/pipeline.ts
@@ -1,5 +1,6 @@
 import { ZodPipelineDef } from "zod";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 import { JsonSchema7AllOfType } from "./intersection.js";
 

--- a/src/parsers/promise.ts
+++ b/src/parsers/promise.ts
@@ -1,5 +1,6 @@
 import { ZodPromiseDef } from "zod";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 
 export function parsePromiseDef(

--- a/src/parsers/record.ts
+++ b/src/parsers/record.ts
@@ -4,7 +4,8 @@ import {
   ZodRecordDef,
   ZodTypeAny,
 } from "zod";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 import { JsonSchema7EnumType } from "./enum.js";
 import { JsonSchema7ObjectType } from "./object.js";

--- a/src/parsers/set.ts
+++ b/src/parsers/set.ts
@@ -1,6 +1,7 @@
 import { ZodSetDef } from "zod";
 import { ErrorMessages, setResponseValueAndErrors } from "../errorMessages.js";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 
 export type JsonSchema7SetType = {

--- a/src/parsers/tuple.ts
+++ b/src/parsers/tuple.ts
@@ -1,5 +1,6 @@
 import { ZodTupleDef, ZodTupleItems, ZodTypeAny } from "zod";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 
 export type JsonSchema7TupleType = {

--- a/src/parsers/union.ts
+++ b/src/parsers/union.ts
@@ -4,7 +4,8 @@ import {
   ZodTypeAny,
   ZodUnionDef,
 } from "zod";
-import { JsonSchema7Type, parseDef } from "../parseDef.js";
+import { parseDef } from "../parseDef.js";
+import { JsonSchema7Type } from "../parseTypes.js";
 import { Refs } from "../Refs.js";
 
 export const primitiveMappings = {

--- a/src/selectParser.ts
+++ b/src/selectParser.ts
@@ -1,0 +1,114 @@
+import { ZodFirstPartyTypeKind } from "zod";
+import { parseAnyDef } from "./parsers/any.js";
+import { parseArrayDef } from "./parsers/array.js";
+import { parseBigintDef } from "./parsers/bigint.js";
+import { parseBooleanDef } from "./parsers/boolean.js";
+import { parseBrandedDef } from "./parsers/branded.js";
+import { parseCatchDef } from "./parsers/catch.js";
+import { parseDateDef } from "./parsers/date.js";
+import { parseDefaultDef } from "./parsers/default.js";
+import { parseEffectsDef } from "./parsers/effects.js";
+import { parseEnumDef } from "./parsers/enum.js";
+import {parseIntersectionDef } from "./parsers/intersection.js";
+import { parseLiteralDef } from "./parsers/literal.js";
+import { parseMapDef } from "./parsers/map.js";
+import { parseNativeEnumDef } from "./parsers/nativeEnum.js";
+import { parseNeverDef } from "./parsers/never.js";
+import { parseNullDef } from "./parsers/null.js";
+import { parseNullableDef } from "./parsers/nullable.js";
+import { parseNumberDef } from "./parsers/number.js";
+import { parseObjectDef } from "./parsers/object.js";
+import { parseOptionalDef } from "./parsers/optional.js";
+import { parsePipelineDef } from "./parsers/pipeline.js";
+import { parsePromiseDef } from "./parsers/promise.js";
+import { parseRecordDef } from "./parsers/record.js";
+import { parseSetDef } from "./parsers/set.js";
+import { parseStringDef } from "./parsers/string.js";
+import { parseTupleDef } from "./parsers/tuple.js";
+import { parseUndefinedDef} from "./parsers/undefined.js";
+import { parseUnionDef } from "./parsers/union.js";
+import {  parseUnknownDef } from "./parsers/unknown.js";
+import { Refs } from "./Refs.js";
+import { parseReadonlyDef } from "./parsers/readonly.js";
+import { JsonSchema7Type } from "./parseTypes.js";
+
+
+export const selectParser = (
+  def: any,
+  typeName: ZodFirstPartyTypeKind,
+  refs: Refs,
+): JsonSchema7Type | undefined | null => {
+  switch (typeName) {
+    case ZodFirstPartyTypeKind.ZodString:
+      return parseStringDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodNumber:
+      return parseNumberDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodObject:
+      return parseObjectDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodBigInt:
+      return parseBigintDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodBoolean:
+      return parseBooleanDef();
+    case ZodFirstPartyTypeKind.ZodDate:
+      return parseDateDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodUndefined:
+      return parseUndefinedDef();
+    case ZodFirstPartyTypeKind.ZodNull:
+      return parseNullDef(refs);
+    case ZodFirstPartyTypeKind.ZodArray:
+      return parseArrayDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodUnion:
+    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
+      return parseUnionDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodIntersection:
+      return parseIntersectionDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodTuple:
+      return parseTupleDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodRecord:
+      return parseRecordDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodLiteral:
+      return parseLiteralDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodEnum:
+      return parseEnumDef(def);
+    case ZodFirstPartyTypeKind.ZodNativeEnum:
+      return parseNativeEnumDef(def);
+    case ZodFirstPartyTypeKind.ZodNullable:
+      return parseNullableDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodOptional:
+      return parseOptionalDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodMap:
+      return parseMapDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodSet:
+      return parseSetDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodLazy:
+      return null;
+    case ZodFirstPartyTypeKind.ZodPromise:
+      return parsePromiseDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodNaN:
+    case ZodFirstPartyTypeKind.ZodNever:
+      return parseNeverDef();
+    case ZodFirstPartyTypeKind.ZodEffects:
+      return parseEffectsDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodAny:
+      return parseAnyDef();
+    case ZodFirstPartyTypeKind.ZodUnknown:
+      return parseUnknownDef();
+    case ZodFirstPartyTypeKind.ZodDefault:
+      return parseDefaultDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodBranded:
+      return parseBrandedDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodReadonly:
+      return parseReadonlyDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodCatch:
+      return parseCatchDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodPipeline:
+      return parsePipelineDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodFunction:
+    case ZodFirstPartyTypeKind.ZodVoid:
+    case ZodFirstPartyTypeKind.ZodSymbol:
+      return undefined;
+    default:
+      /* c8 ignore next */
+      return ((_: never) => undefined)(typeName);
+  }
+};

--- a/src/zodToJsonSchema.ts
+++ b/src/zodToJsonSchema.ts
@@ -1,6 +1,7 @@
 import { ZodSchema } from "zod";
 import { Options, Targets } from "./Options.js";
-import { JsonSchema7Type, parseDef } from "./parseDef.js";
+import { parseDef } from "./parseDef.js";
+import { JsonSchema7Type } from "./parseTypes.js";
 import { getRefs } from "./Refs.js";
 
 const zodToJsonSchema = <Target extends Targets = "jsonSchema7">(


### PR DESCRIPTION
Hello @StefanTerdell, hope you are doing well.

First, this is a lot of work to maintain this package alone and it's great!

I saw that this issue #118 is being around a while without a fix, mainly because is not a critical error or something, but still pending.

Basically, we wanted to get rid of the warning logs for circular dependencies. At the moment, I didn't see any run time error while using it on super forms for svelte, but I wanted to remove the logs.

So, this is my contribution to this.

**Changes:**
- Move types to a single file: the types used by the `parseDef` are now on single file. This way the parsers can import it without making a circular dependency.
- Move the `selectParser`: the `selectParser` function to a single file. This require that the return strictly `null` if the selected parser is the `parseDef`. Then, inside `parseDef`, if the return is an strictly null (`response === null`), then we consider that as call to `parseDef` again. 

These changes make possible to solve the circular dependency. Maybe it's not the pretty solution, but it was the easier in my opinion.

