### PR TITLE
Add link to Zod v4's toJSONSchema method

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Notice of deprecation
 
-As of November 2025, this project will no longer be receiving updates. Zod v4 natively supports generating JSON schemas, so I recommend you switch to the new major, or better yet, a [decent language](https://rust-lang.org/) ;)
+As of November 2025, this project will no longer be receiving updates. [Zod v4 natively supports generating JSON schemas](https://zod.dev/json-schema#ztojsonschema), so I recommend you switch to the new major, or better yet, a [decent language](https://rust-lang.org/) ;)
 
 Thank you to all the contributors and sponsors throughout the years! So long, and thanks for all the fish.
 


### PR DESCRIPTION
The deprecation notice refers to Zod v4's native support for generating JSON schemas, but doesn't link to the corresponding method. This PR adds what I think is the correct link.